### PR TITLE
clickanddraw: Workaround for unclickable points

### DIFF
--- a/src/activities/drawnumber/Drawnumber.qml
+++ b/src/activities/drawnumber/Drawnumber.qml
@@ -109,7 +109,7 @@ ActivityBase {
                     sourceSize.height: background.height / 15
                     x: modelData[0] * background.width / 801 - sourceSize.height/2
                     y: modelData[1] * background.height / 521 - sourceSize.height/2
-                    z: items.pointIndexToClick >= index ? 10 : 1
+                    z: items.pointIndexToClick <= index ? 10 : 1
                     visible: index == pointImageRepeater.count - 1 &&
                              items.pointIndexToClick == 0 ? false : true
 


### PR DESCRIPTION
It is not enough to just change z index for points in order to make them
clickable. The problem is that points later in the click index grab the
click instead of the current point to click.

As a workaround the pointIndexToClick comparison with (current?) index
is reversed, to show where the point is actually clickable.