### PR TITLE
Bug: userEntry max length is 3. 

### DIFF
--- a/src/activities/target/Target.qml
+++ b/src/activities/target/Target.qml
@@ -155,7 +155,7 @@ ActivityBase {
                 userEntry.text = ""
             }
 
-            if(userEntry.text.length >= 3) {
+            if(userEntry.text.length >= 4) {
                 return
             }
 


### PR DESCRIPTION
It is a problem in level 7 (with 500 in the center of the target) because the total can be bigger than 999. I change length test with 4.

Tiny changset, but my son found the problem this afternoon.

Very nice job with this new GCompris. Best regards.