### PR TITLE
Correct navigation when image removes

### DIFF
--- a/src/activities/babymatch/DragListItem.qml
+++ b/src/activities/babymatch/DragListItem.qml
@@ -117,7 +117,7 @@ Item {
                 toSmall()
                 tileImage.parent = tileImage.tileImageParent
                 tileImage.anchors.centerIn = tileImage.tileImageParent
-
+				updateOkButton()
 //                tileImageAnimation.start()
             }
 


### PR DESCRIPTION
I found an issue, and this a one line solution for it. 
Issue can be reproduced as:
1) Go to Find the details activity.
2) Go to level 4.
3) Click on next navigation button. 
4) Place all the images from ListWidget (of 2nd Navigation) on the drop points. You will then automatically come to 1st navigation (As 2nd Navigation ListWidget or currentDisplayedGroup will become empty).
5) Then place an image from the ListWidget on any of the previously placed image. This image will replace the previously placed image.
6) Now the previously placed image which is removed will go back to the ListWidget (in the 2nd Navigation), but no next navigation button (arrow) will appear.