### PR TITLE
fixed Colorize bug in Click_on_letter

### DIFF
--- a/src/activities/click_on_letter/Carriage.qml
+++ b/src/activities/click_on_letter/Carriage.qml
@@ -1,7 +1,7 @@
 /* GCompris - Carriage.qml
  *
  * Copyright (C) 2014 Holger Kaelberer  <holger.k@elberer.de>
- * 
+ *
  * Authors:
  *   Pascal Georges <pascal.georges1@free.fr> (GTK+ version)
  *   Bruno Coudoin <bruno.coudoin@gcompris.net> (GTK+ Mostly full rewrite)
@@ -27,122 +27,138 @@ import QtGraphicalEffects 1.0
 import "../../core"
 import "click_on_letter.js" as Activity
 
-Image {
-    id: carriageImage
-    fillMode: Image.PreserveAspectFit
-    source: isCarriage ?
-                Activity.url + "carriage.svg":
-                Activity.url + "cloud.svg"
-    z: (state == 'scaled') ? 1 : -1
+Item {
+    id: carriageItem
     property int nbCarriage
     property bool isCarriage: index <= nbCarriage
 
-    Rectangle {
-        id: carriageBg
-        visible: isCarriage
-        width: parent.width - 8
-        height: parent.height / 1.8
-        anchors.bottom: parent.top
-        anchors.bottomMargin: - parent.height / 1.5
-        radius: height / 10
-        color: "#f0d578"
-        border.color: "#b98a1c"
-        border.width: 3
-    }
+    Image {
+        id: carriageImage
+        sourceSize.width: carriageItem.width
+        fillMode: Image.PreserveAspectFit
+        source: isCarriage ?
+                    Activity.url + "carriage.svg":
+                    Activity.url + "cloud.svg"
+        z: (state == 'scaled') ? 1 : -1
 
-    GCText {
-        id: text
-        anchors.horizontalCenter: isCarriage ?
-                                      carriageBg.horizontalCenter :
-                                      parent.horizontalCenter
-        anchors.verticalCenter: isCarriage ?
-                                    carriageBg.verticalCenter :
-                                    parent.verticalCenter
-        z: 11
+        Rectangle {
+            id: carriageBg
+            visible: isCarriage
+            width: parent.width - 8
+            height: parent.height / 1.8
+            anchors.bottom: parent.top
+            anchors.bottomMargin: - parent.height / 1.5
+            radius: height / 10
+            color: "#f0d578"
+            border.color: "#b98a1c"
+            border.width: 3
+        }
 
-        text: letter
-        font.pointSize: NaN  // need to clear font.pointSize explicitly 
-        font.pixelSize: parent.width * 0.65
-        font.bold: true
-        style: Text.Outline
-        styleColor: "#2a2a2a"
-        color: "white"
-    }
+        GCText {
+            id: text
+            anchors.horizontalCenter: isCarriage ?
+                                          carriageBg.horizontalCenter :
+                                          parent.horizontalCenter
+            anchors.verticalCenter: isCarriage ?
+                                        carriageBg.verticalCenter :
+                                        parent.verticalCenter
+            z: 11
 
-    DropShadow {
-        anchors.fill: text
-        cached: false
-        horizontalOffset: 1
-        verticalOffset: 1
-        radius: 3
-        samples: 16
-        color: "#422a2a2a"
-        source: text
-    }
+            text: letter
+            font.pointSize: NaN  // need to clear font.pointSize explicitly
+            font.pixelSize: parent.width * 0.65
+            font.bold: true
+            style: Text.Outline
+            styleColor: "#2a2a2a"
+            color: "white"
+        }
 
-    MouseArea {
-        id: mouseArea
-        anchors.fill: parent
-        hoverEnabled: ApplicationInfo.isMobile ? false : true
+        DropShadow {
+            anchors.fill: text
+            cached: false
+            horizontalOffset: 1
+            verticalOffset: 1
+            radius: 3
+            samples: 16
+            color: "#422a2a2a"
+            source: text
+        }
 
-        onClicked: {
-            if (Activity.checkAnswer(index)) {
-                successAnimation.restart();
-                particle.burst(30)
-            } else {
-                failureAnimation.restart()
+        MouseArea {
+            id: mouseArea
+            anchors.fill: parent
+            hoverEnabled: ApplicationInfo.isMobile ? false : true
+
+            onClicked: {
+                if (Activity.checkAnswer(index)) {
+                    successAnimation.restart();
+                    particle.burst(30)
+                } else {
+                    failureAnimation.restart()
+                }
+            }
+        }
+
+        ParticleSystemStarLoader {
+            id: particle
+            clip: false
+        }
+
+        states: State {
+            name: "scaled"; when: mouseArea.containsMouse
+            PropertyChanges {
+                target: carriageItem
+                scale: /*carriageImage.scale * */ 1.2
+                z: 2}
+        }
+
+        transitions: Transition {
+            NumberAnimation { properties: "scale"; easing.type: Easing.OutCubic }
+        }
+
+        SequentialAnimation {
+            id: successAnimation
+            NumberAnimation {
+                target: carriageImage
+                easing.type: Easing.InOutQuad
+                property: "rotation"
+                to: 20; duration: 100
+            }
+            NumberAnimation {
+                target: carriageImage
+                easing.type: Easing.InOutQuad
+                property: "rotation"; to: -20
+                duration: 100 }
+            NumberAnimation {
+                target: carriageImage
+                easing.type: Easing.InOutQuad
+                property: "rotation"
+                to: 0
+                duration: 50 }
+        }
+
+        SequentialAnimation {
+            id: failureAnimation
+            NumberAnimation {
+                target: color
+                property: "opacity"
+                to: 1; duration: 400
+            }
+            NumberAnimation {
+                target: color
+                property: "opacity"
+                to: 0; duration: 200
             }
         }
     }
 
-    ParticleSystemStarLoader {
-        id: particle
-        clip: false
-    }
-
-    states: State {
-        name: "scaled"; when: mouseArea.containsMouse
-        PropertyChanges {
-            target: carriageImage
-            scale: /*carriageImage.scale * */ 1.2 }
-    }
-
-    transitions: Transition {
-        NumberAnimation { properties: "scale"; easing.type: Easing.OutCubic }
-    }
-
-    SequentialAnimation {
-        id: successAnimation
-        NumberAnimation {
-            target: carriageImage
-            easing.type: Easing.InOutQuad
-            property: "rotation"
-            to: 20; duration: 100
+    Colorize {
+            id: color
+            z: 5
+            anchors.fill: carriageImage
+            source: carriageImage
+            hue: 0.0
+            saturation: 1
+            opacity: 0
         }
-        NumberAnimation {
-            target: carriageImage
-            easing.type: Easing.InOutQuad
-            property: "rotation"; to: -20
-            duration: 100 }
-        NumberAnimation {
-            target: carriageImage
-            easing.type: Easing.InOutQuad
-            property: "rotation"
-            to: 0
-            duration: 50 }
-    }
-
-    SequentialAnimation {
-        id: failureAnimation
-        NumberAnimation {
-            target: color
-            property: "opacity"
-            to: 1; duration: 400
-        }
-        NumberAnimation {
-            target: color
-            property: "opacity"
-            to: 0; duration: 200
-        }
-    }
 }

--- a/src/activities/click_on_letter/ClickOnLetter.qml
+++ b/src/activities/click_on_letter/ClickOnLetter.qml
@@ -1,7 +1,7 @@
 /* GCompris - ClickOnLetter.qml
  *
  * Copyright (C) 2014 Holger Kaelberer  <holger.k@elberer.de>
- * 
+ *
  * Authors:
  *   Pascal Georges <pascal.georges1@free.fr> (GTK+ version)
  *   Bruno Coudoin <bruno.coudoin@gcompris.net> (GTK+ Mostly full rewrite)
@@ -31,7 +31,7 @@ import "qrc:/gcompris/src/core/core.js" as Core
 ActivityBase {
     id: activity
     focus: true
-    
+
     /* mode of the activity, either "lowercase" (click_on_letter)
      * or "uppercase" (click_on_letter_up): */
     property string mode: "lowercase"
@@ -51,13 +51,13 @@ ActivityBase {
         signal start
         signal stop
         signal voiceError
-        
+
         Component.onCompleted: {
             dialogActivityConfig.getInitialConfiguration()
             activity.start.connect(start)
             activity.stop.connect(stop)
         }
-        
+
         QtObject {
             id: items
             property Item main: activity.main
@@ -71,7 +71,7 @@ ActivityBase {
             property alias bonus: bonus
             property alias locale: background.locale
         }
-        
+
         onVoiceError: {
             questionItem.visible = true
             repeatItem.visible = false
@@ -244,7 +244,7 @@ ActivityBase {
                 anchors.horizontalCenter: parent.horizontalCenter
                 anchors.verticalCenter: parent.verticalCenter
                 opacity: 1.0
-                z:11            
+                z:11
                 text: ""
                 fontSize: 44
                 font.bold: true
@@ -309,10 +309,9 @@ ActivityBase {
             interactive: false
             verticalLayoutDirection: GridView.BottomToTop
             layoutDirection: Qt.LeftToRight
-            
+
             model: trainModel
             delegate: Carriage {
-                sourceSize.width: background.itemWidth
                 width: background.itemWidth
                 nbCarriage: (parent.width - engine.width) / background.itemWidth
             }


### PR DESCRIPTION
In Click_on_letter, when pressing a wrong carriage, nothing happens, because the Colorize effect is not added. The effect was removed in this commit: [hexagon, fix colorize effect] (https://github.com/bdoin/GCompris-qt/commit/006d11ed9bb50590d9e373a9477f6d3d80d421c7) and i added it back so it works on Android as well as other distributions.
Now, when clicking on a bad carriage, it is colored red, as before the Colorize effect removal.
// in "ClickOnLetter.qml", there are some spaces introduced by my computer (i don't know how) and i could not remove them; i hope its ok still