### PR TITLE
Use imgWidth and imgHeight of images when defined in the dataset, and remove some unused variables.

### DIFF
--- a/src/activities/babymatch/DragListItem.qml
+++ b/src/activities/babymatch/DragListItem.qml
@@ -89,12 +89,12 @@ Item {
 
             property double smallWidth: Activity.glowEnabled ? widthInColumn * 1.1 : widthInColumn
             property double smallHeight: Activity.glowEnabled ? heightInColumn * 1.1 : heightInColumn
-            property double fullWidth: backgroundImage.source == "" ?
-                                           backgroundImage.width * tileImage.sourceSize.width/backgroundImage.width :
-                                           backgroundImage.width * tileImage.sourceSize.width/backgroundImage.sourceSize.width
-            property double fullHeight: backgroundImage.source == "" ?
-                                            backgroundImage.height * tileImage.sourceSize.height/backgroundImage.height :
-                                            backgroundImage.height * tileImage.sourceSize.height/backgroundImage.sourceSize.height
+            property double fullWidth: imgWidth ? imgWidth * backgroundImage.width : (backgroundImage.source == "" ?
+                                           tileImage.sourceSize.width :
+                                           backgroundImage.width * tileImage.sourceSize.width/backgroundImage.sourceSize.width)
+            property double fullHeight: imgHeight ? imgHeight * backgroundImage.height : (backgroundImage.source == "" ?
+                                           tileImage.sourceSize.height :
+                                           backgroundImage.height * tileImage.sourceSize.height/backgroundImage.sourceSize.height)
             property QtObject tileImageParent
             property double moveImageX
             property double moveImageY

--- a/src/activities/babymatch/DropAnswerItem.qml
+++ b/src/activities/babymatch/DropAnswerItem.qml
@@ -29,8 +29,6 @@ Rectangle {
     property string text
     property double posX
     property double posY
-    property double imgHeight
-    property double imgWidth
     property string imgName
     property double xCenter: x + width / 2
     property double yCenter: y + height / 2

--- a/src/activities/babymatch/babymatch.js
+++ b/src/activities/babymatch/babymatch.js
@@ -143,11 +143,7 @@ function initLevel() {
                          items.backgroundImage, {
                             "posX": levelData.levels[i].x,
                             "posY": levelData.levels[i].y,
-                            "imgHeight": levelData.levels[i].height == undefined ? 0 : levelData.levels[i].height,
-                            "imgWidth": levelData.levels[i].width == undefined ? 0 : levelData.levels[i].width,
-                            "dropAreaSize": levelData.levels[i].dropAreaSize == undefined ? 15 : levelData.levels[i].dropAreaSize,
                             "imgName" : levelData.levels[i].pixmapfile,
-                            "factor": Math.max(3, 1.0 / levelData.levels.length * 100)
                          });
         }
         //Create Text pieces for the level which has to display additional information


### PR DESCRIPTION
This will correct the image size problem after it is dropped (As in the case of Chronos level 4), and some unused variables are removed.