### PR TITLE
fixed "Bad" Voice ("Check Answer") after passing a sublevel in Algorithm

### DIFF
--- a/src/activities/algorithm/Algorithm.qml
+++ b/src/activities/algorithm/Algorithm.qml
@@ -228,7 +228,7 @@ ActivityBase {
 
         Bonus {
             id: bonus
-            Component.onCompleted: win.connect(Activity.nextLevel)
+            Component.onCompleted: win.connect(Activity.nextSubLevel)
         }
 
         Score {

--- a/src/activities/algorithm/algorithm.js
+++ b/src/activities/algorithm/algorithm.js
@@ -92,7 +92,7 @@ var sample = [[[0,1,0,1,0,1,0,1],[0,1,1,0,0,1,1,0],[1,1,0,0,0,0,1,1],[1,0,0,1,0,
               [[0,1,2,3,0,1,2,0],[0,1,2,3,1,2,3,1],[0,1,2,3,2,1,3,1],[0,1,2,3,3,1,2,1]],//4
               [[0,1,2,3,1,2,3,0],[0,1,2,3,2,3,0,1],[0,1,2,3,3,0,1,2],[0,1,2,3,3,0,1,2]],//5
               [[0,1,2,3,3,1,2,0],[0,1,2,3,0,2,1,3],[0,1,2,3,2,3,1,0],[0,1,2,3,2,1,3,0]],//6
-	      [[0,1,2,3,3,0,1,1],[0,1,2,3,2,2,3,2],[0,1,2,3,1,1,0,3],[0,1,2,3,1,2,3,2]]]//7
+              [[0,1,2,3,3,0,1,1],[0,1,2,3,2,2,3,2],[0,1,2,3,1,1,0,3],[0,1,2,3,1,2,3,2]]]//7
 var numberOfLevel = sample.length
 
 function setUp(){
@@ -155,16 +155,10 @@ function clickHandler(id){
         items.answer.model = tempIndex
 
         if(choiceCount == max){
-            choiceCount = matchesVisible
-            items.currentSubLevel++
-            if(items.currentSubLevel == items.nbSubLevel) { // increment level after 3 successful games
-                items.currentSubLevel-- // Don't display 4/3
+            if(items.currentSubLevel+1 === items.nbSubLevel)
                 items.bonus.good("tux")
-            } else {
+            else
                 items.bonus.good("flower")
-                items.bonus.isWin = false
-                setUp()
-            }
         }
         return 1
     } else { // Wrong answer, try again
@@ -180,6 +174,15 @@ function nextLevel() {
     initLevel();
 }
 
+function nextSubLevel() {
+    choiceCount = matchesVisible
+    items.currentSubLevel++
+    if (items.currentSubLevel === items.nbSubLevel) {// increment level after 3 successful games
+        nextLevel()
+    }
+    setUp()
+}
+
 
 function previousLevel() {
     if(--currentLevel < 0) {
@@ -188,4 +191,3 @@ function previousLevel() {
     items.currentSubLevel = 0;
     initLevel();
 }
-


### PR DESCRIPTION
In Algorithm, after passing sublevels 1 and 2, "items.bonus.good("flower")" is showing the flower, because the sublevel was passed, but to prevent it from going to the next level, was added "items.bonus.isWin = false", which plays a "bad sound".
I changed the Bonus in Algorithm.qml to go to the next SubLevel, instead the next Level; passing to the next level is now handeled in the "nextSubLevel" function.
At the end of a sublevel is still displayed a flower and at the end of the levels is shown Tux, as before, but now, it plays good sounds at the passing of each sublevel.