### PR TITLE
Correct babymatch activities when GCompris window is resized

### DIFF
--- a/src/activities/babymatch/DragListItem.qml
+++ b/src/activities/babymatch/DragListItem.qml
@@ -103,6 +103,16 @@ Item {
             property Item currentTargetSpot
             property bool pressedOnce
             property bool parentIsTile : parent == tile ? true : false
+            
+            onFullWidthChanged: correctDroppedImageSize()
+            onFullHeightChanged: correctDroppedImageSize()
+
+            function correctDroppedImageSize() {
+                if(tileImage.dropStatus == 0 || tileImage.dropStatus == 1) {
+                    tileImage.width = tileImage.fullWidth
+                    tileImage.height = tileImage.fullHeight
+                }
+            }
 
             function imageRemove() {
                 dropStatus = -1

--- a/src/activities/babymatch/ListWidget.qml
+++ b/src/activities/babymatch/ListWidget.qml
@@ -164,6 +164,7 @@ Item {
                 }
                 i++
             }
+            
             if (groupEmpty) {
                 displayedGroup[currentDisplayedGroup] = false
                 previousNavigation = 0
@@ -260,7 +261,7 @@ Item {
             Image {
                 id: next
                 visible: model.count > view.nbItemsByGroup && view.nextNavigation != 0 && view.currentDisplayedGroup < 
-                         view.nbDisplayedGroup - 1
+						 view.nbDisplayedGroup - 1
                 source:"qrc:/gcompris/src/core/resource/bar_next.svg"
                 sourceSize.width: view.iconSize * 0.35
                 fillMode: Image.PreserveAspectFit

--- a/src/activities/babymatch/ListWidget.qml
+++ b/src/activities/babymatch/ListWidget.qml
@@ -101,6 +101,8 @@ Item {
         property var displayedGroup: []
         property alias ok: ok
         
+        onNbDisplayedGroupChanged: correctDisplayedGroup()
+        
         add: Transition {
             NumberAnimation { property: "opacity"; from: 0; to: 1.0; duration: 400 }
             NumberAnimation { property: "scale"; from: 0; to: 1.0; duration: 400 }
@@ -108,6 +110,27 @@ Item {
 
         move: Transition {
             NumberAnimation { properties: "x,y"; duration: 400; easing.type: Easing.OutBounce }
+        }
+
+        // For correcting values of Displayed Groups when height or width is changed
+        function correctDisplayedGroup() {
+            if (nbDisplayedGroup > 0) {
+                for(var i = 0 ; i < nbDisplayedGroup ; i++) {
+                    var groupEmpty = true
+                    for(var j = 0 ; j < nbItemsByGroup, i*nbItemsByGroup + j < model.count ; j++) {
+                        if (repeater.itemAt(i*nbItemsByGroup + j).dropStatus < 0) {
+                            groupEmpty = false
+                            break
+                        }
+                    }
+                    if (groupEmpty) 
+                        displayedGroup[i] = false
+                    else
+                        displayedGroup[i] = true
+                }
+                view.refreshLeftWidget()
+                view.checkDisplayedGroup()
+            }
         }
 
         //For setting navigation buttons
@@ -141,7 +164,6 @@ Item {
                 }
                 i++
             }
-            
             if (groupEmpty) {
                 displayedGroup[currentDisplayedGroup] = false
                 previousNavigation = 0
@@ -238,7 +260,7 @@ Item {
             Image {
                 id: next
                 visible: model.count > view.nbItemsByGroup && view.nextNavigation != 0 && view.currentDisplayedGroup < 
-						 view.nbDisplayedGroup - 1
+                         view.nbDisplayedGroup - 1
                 source:"qrc:/gcompris/src/core/resource/bar_next.svg"
                 sourceSize.width: view.iconSize * 0.35
                 fillMode: Image.PreserveAspectFit


### PR DESCRIPTION
This includes 
1) Missing of navigation buttons when number of items in a screen (nbItemsByGroup) changes due to resizing of the GCompris window.
2) Resizing of images when the GCompris window is resized.